### PR TITLE
Ignore macOS custom icon files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 code/env
+Icon?
+![Ii]con[_a-zA_Z0-9-]


### PR DESCRIPTION
In a follow up to the previous commit removing such files, have
git ignore them entirely.

The two-line stanza works around there being no way to escape
non-printable characters is .gitignore, so we ignore Icon +
any following character, as long as it isn't a common printed
character. This will hopefully avoid confusion if someone tries
to add a file named IconA, icon-45, or similar.

See this discussion for more information:
https://stackoverflow.com/questions/17556250/how-to-ignore-icon-in-git

Closes #23