### PR TITLE
Fix partial-quadrat red markup on line 13.12

### DIFF
--- a/mdc_pages/page13.gly
+++ b/mdc_pages/page13.gly
@@ -22,4 +22,4 @@
 |13.9-P7-W-i-i-P1-m-D53:Y1-t:A-N6:d-nTrw-G7-Z3-wn:n-i:n-G41-A-P1-Z1:n-stX-G7-Hr-Z1-h-r:p-W-mw-A24-m-G41-A-mw-$r-aHa-a:n-$b-stX-G7-Hr-Z1-ir:(r-t)-xpr-i-Z5:Y1-Z2:f-m-wa:(a-Z1)-d-b-W-F27-Z3-!
 |13.10-i-W-f-D37:t-b-G41-A-g-A-i-i-A7-y:G37-G41-A-P1-Z1:n-G5-G7-$r-wn:n-i:n-$b-G5-G7-Hr-Z1-TA-A-i-i-D51:D40-N34-Z1-N33:Z2-f-i-W-f-H-A24-Z12-A24-t-W-f-r-Hm-Z1-G7:n-stX-G7-$r-wn:n-i:n-$b-!
 |13.11-t:A-N6:d-nTrw-G7-Z3-Hr-Z1-D&d-n:f-m-ir-H-A24-Z12-A24-t-W-f-r:f-$r-wn:n-i-n:f-$b-Hr-Z1-ini:n-n:A-xa:a-W-xt:Z2-n-G41-A-mw-i-W-f-wAH-H-Y1-W-Z3A-m-G41-A-i-i-f-P1-Z1-i-W-f-x:d-P1-!
-|13.12-r-z:zA-i-i-niwt-r:(D&d)-n:(t-H8)-G7-wr:r-nTr-mwt-t:H8-I12-i-m-m:a-W-D&a-Aa21\R90-Y1-A24-t-W-H-n:a-stX-G7-r:n:(t-y)-40\99**40{{12,797,100}}:n-rnp-t-Z1-r-t:A-y-i-W-n:n:Z2-m-t:A-O38\107**t{{26,731,73}}**Z5{{372,530,57}}-A1:Z2-!
+|13.12-r-z:zA-i-i-niwt-r:(D&d)-n:(t-H8)-G7-wr:r-nTr-mwt-t:H8-I12-i-m-m:a-W-D&a-Aa21\R90-Y1-A24-t-W-H-n:a-stX-G7-r:n:(t-y)-40\red\99**40\red{{12,797,100}}:n-rnp-t-Z1-r-t:A-y-i-W-n:n:Z2-m-t:A-O38\107**t{{26,731,73}}**Z5{{372,530,57}}-A1:Z2-!


### PR DESCRIPTION
The number is in red in the hieratic, but setting part of a group to a colour doesn't seem to be possible in the gui. The manual [suggests](https://github.com/rosmord/jsesh/blob/release-7.6.1/jsesh-installer/src/binary/texts/A_demonstration_of_the_mdc.gly#L158-L161) appending `\red` to individual signs in the MdC to accomplish this.